### PR TITLE
ci: macos-latest is changing to macos-14 ARM runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.7, 3.9]
-        runs-on: [ubuntu-latest, macos-latest, windows-latest]
+        runs-on: [ubuntu-latest, macos-13, windows-latest]
 
         include:
         - python-version: pypy-3.7


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos