### PR TITLE
chore: update of dependencies and minor chore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.12", "3.13", "3.14"]
         runs-on: [ubuntu-latest, macos-15, windows-latest]
         include:
           - python-version: "3.12"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
   rev: v3.21.2
   hooks:
   - id: pyupgrade
-    args: ["--py36-plus"]
+    args: ["--py310-plus"]
 
 - repo: https://github.com/asottile/setup-cfg-fmt
   rev: v3.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,8 +20,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -31,7 +29,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.10
 include_package_data = True
 package_dir =
     =src
@@ -64,7 +62,7 @@ per-file-ignores =
 
 [mypy]
 files = src
-python_version = 3.8
+python_version = 3.10
 warn_unused_configs = True
 disallow_any_generics = True
 disallow_subclassing_any = True


### PR DESCRIPTION
Some little things worth updating, especially that mplhep itself is now Python 3.10+.

I would suggest making a release 0.1.0 after this.